### PR TITLE
Add issue tracker to manifest

### DIFF
--- a/custom_components/sonos_alarm/manifest.json
+++ b/custom_components/sonos_alarm/manifest.json
@@ -3,6 +3,7 @@
   "name": "Sonos Alarm",
   "config_flow": true,
   "documentation": "https://github.com/AaronDavidSchneider/SonosAlarm/blob/master/README.md",
+  "issue_tracker": "https://github.com/AaronDavidSchneider/SonosAlarm/issues",
   "requirements": [
     "pysonos"
   ],


### PR DESCRIPTION
I noticed that the issue tracker link was missing under https://my.home-assistant.io/redirect/info/
![image](https://user-images.githubusercontent.com/2124386/114997831-91065780-9ea0-11eb-83d3-c4bb9c67441a.png)

This PR solves that