### PR TITLE
Change device name and id

### DIFF
--- a/custom_components/sonos_alarm/switch.py
+++ b/custom_components/sonos_alarm/switch.py
@@ -246,29 +246,17 @@ class SonosAlarmSwitch(SwitchEntity):
         """Return a unique ID."""
         return self._unique_id
 
-#    For future reference: Use the same device_info like sonos: -> needs some way to update the device_info
-#
-#    @property
-#    def device_info(self) -> dict:
-#        """Return information about the device."""
-#        return {
-#            "identifiers": {(SONOS_DOMAIN, self._unique_player_id)},
-#            "name": self._speaker_name,
-#            "model": self._model.replace("Sonos ", ""),
-#            "sw_version": self._sw_version,
-#            "connections": {(dr.CONNECTION_NETWORK_MAC, self._mac_address)},
-#            "manufacturer": "Sonos",
-#            "suggested_area": self._speaker_name,
-#        }
-#
     @property
     def device_info(self) -> dict:
         """Return information about the device."""
         return {
-            "identifiers": {(SONOS_DOMAIN, self._unique_id)},
-            "name": "Sonos Alarm - ID: {}".format(self._id),
-            "model": "alarm",
+            "identifiers": {(SONOS_DOMAIN, self._unique_player_id)},
+            "name": self._speaker_name,
+            "model": self._model.replace("Sonos ", ""),
+            "sw_version": self._sw_version,
+            "connections": {(dr.CONNECTION_NETWORK_MAC, self._mac_address)},
             "manufacturer": "Sonos",
+            "suggested_area": self._speaker_name,
         }
 
 


### PR DESCRIPTION
I looked at the recent changes you did and noticed that every alarm became a different device.
This PR fixed that partially, with one drawback.

Pros:
- All alarms for one speaker is grouped to the same device
- Nicer names for the devices

Cons:
- When an alarm is moved to another speaker a restart is needed to move the entity to the correct device (since `device_info` cannot be updated). But the entity name will be updated directly so it shouldn't be a big problem.

I'm thinking that keeping the entities together in the correct device is a bigger win than the drawback of getting the devices completely correct without a restart.