### PR TITLE
Disable polling

### DIFF
--- a/custom_components/sonos_alarm/__init__.py
+++ b/custom_components/sonos_alarm/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.core import callback
 
-from .const import DOMAIN
+from .const import DOMAIN, DATA_SONOS
 
 CONF_ADVERTISE_ADDR = "advertise_addr"
 CONF_INTERFACE_ADDR = "interface_addr"

--- a/custom_components/sonos_alarm/__init__.py
+++ b/custom_components/sonos_alarm/__init__.py
@@ -61,27 +61,6 @@ async def async_setup_entry(hass, entry):
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, domain)
         )
-    async_cleanup_sonos_devices(hass, entry)
     return True
 
 
-@callback
-def async_cleanup_sonos_devices(hass, entry):
-    """Clean up old and invalid devices from the registry."""
-    device_registry = dr.async_get(hass)
-    entity_registry = er.async_get(hass)
-
-    device_entries = hass.helpers.device_registry.async_entries_for_config_entry(
-        device_registry, entry.entry_id
-    )
-
-    for device_entry in device_entries:
-        if (
-                len(
-                    hass.helpers.entity_registry.async_entries_for_device(
-                        entity_registry, device_entry.id, include_disabled_entities=True
-                    )
-                )
-                == 0
-        ):
-            device_registry.async_remove_device(device_entry.id)

--- a/custom_components/sonos_alarm/const.py
+++ b/custom_components/sonos_alarm/const.py
@@ -1,3 +1,4 @@
 """Const for Sonos Alarm."""
 
 DOMAIN = "sonos_alarm"
+DATA_SONOS = "sonos_alarm_switch"

--- a/custom_components/sonos_alarm/switch.py
+++ b/custom_components/sonos_alarm/switch.py
@@ -17,7 +17,7 @@ from homeassistant.components.switch import ENTITY_ID_FORMAT, SwitchEntity
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
 )
-
+from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import slugify
 
@@ -305,9 +305,10 @@ class SonosAlarmSwitch(SwitchEntity):
         entity_registry.async_remove(self.entity_id)
 
 
+    @callback
     def async_update_alarm(self, event = None):
         """Update information about alarm """
-        self.hass.async_add_job(self.async_remove_if_not_available(event))
+        self.hass.async_add_job(self.async_remove_if_not_available, event)
         self.hass.async_add_executor_job(self.update_alarm, event)
 
 

--- a/custom_components/sonos_alarm/switch.py
+++ b/custom_components/sonos_alarm/switch.py
@@ -256,15 +256,9 @@ class SonosAlarmSwitch(SwitchEntity):
         """Return soco object."""
         return self.alarm.zone
 
-    def _attach_player(self) -> None:
-        """Get basic information and add event subscriptions."""
-        self._play_mode = self.soco.play_mode
-
     async def _async_attach_player(self) -> bool:
         """Get basic information and add event subscriptions."""
         try:
-            await self.hass.async_add_executor_job(self._attach_player)
-
             player = self.soco
 
             if self._subscriptions:


### PR DESCRIPTION
This rather large PR disables polling and therefore increases the stability and quality of the component.

We now subscribe to updates of the alarm and update the state only when necessary. This reduces the amount of computations that need to be performed. It also speeds up the update process.